### PR TITLE
Fix README link (404 error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is the coordination repository of the RFMIG
 
-The homepage is [here](https://rust-formal-methods.github.io/website/).
+The homepage is [here](https://rust-formal-methods.github.io).


### PR DESCRIPTION
The link in the README, [https://rust-formal-methods.github.io/website/](https://rust-formal-methods.github.io/website/), returns a 404.

This PR changes it to [https://rust-formal-methods.github.io](https://rust-formal-methods.github.io), the current URL.